### PR TITLE
Fix FirefoxDriver.quit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>selenium-cucumber</groupId>
 	<artifactId>selenium-cucumber-java</artifactId>
-	<version>0.1.3</version>
+	<version>0.1.10</version>
 	<packaging>jar</packaging>
 	<name>selenium-cucumber-java</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,29 +34,29 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>3.5.3</version>
+			<version>3.7.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-server</artifactId>
-			<version>3.5.3</version>
+			<version>3.7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-firefox-driver</artifactId>
-			<version>3.5.3</version>
+			<version>3.7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-remote-driver</artifactId>
-			<version>3.5.3</version>
+			<version>3.7.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>21.0</version>
+			<version>23.3-jre</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/env/DriverUtil.java
+++ b/src/main/java/env/DriverUtil.java
@@ -127,10 +127,9 @@ public class DriverUtil {
     	System.out.println("DriverUtil.closeDriver");
 		if (driver != null) {
 			try {
-				System.out.println("DriverUtil.closeDriver closing...");
-				driver.close();
+				System.out.println("DriverUtil.closeDriver quiting...");
+				driver.quit();
 				System.out.println("DriverUtil.closeDriver closed");
-				// driver.quit(); // fails in current geckodriver! TODO: Fixme
 			} catch (NoSuchMethodError nsme) {
 				// in case quit fails
 				System.out.println("DriverUtil.closeDriver: NoSuchMethodError");

--- a/src/test/java/stepDefintions/UserStepDefinitions.java
+++ b/src/test/java/stepDefintions/UserStepDefinitions.java
@@ -1,6 +1,11 @@
 package stepDefintions;
+import cucumber.api.java.After;
 import env.BaseTest;
+import env.DriverUtil;
 
 public class UserStepDefinitions implements BaseTest {
-
+	@After
+	public void after() {
+		DriverUtil.closeDriver();
+	}
 }


### PR DESCRIPTION
Fixes the no such method exception caused when calling FirefoxDriver.quit() by updating the guava dependency.

Also, updates selenium to version 3.7.0